### PR TITLE
switch to the `asserting` crate for assertions in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ threadsafe = []
 thiserror = "2"
 
 [dev-dependencies]
-assertor = "0.0.3"
+asserting = "0.1"
 proptest = "1"
 version-sync = "0.9"
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ impl Adapter {
 //
 // Test
 //
-use assertor::*;
+use asserting::prelude::*;
 
 // this is a test method in a test module
 // main() method is used here in the example so that it is compiled and run during doc-tests
@@ -99,7 +99,7 @@ fn main() {
 
     let tracker_output = tracker.output().unwrap();
 
-    assert_that!(tracker_output).contains_exactly_in_order(vec![
+    assert_that!(tracker_output).contains_exactly(vec![
         Message {
             topic: "weather report".to_string(),
             content: "it will be snowing tomorrow".to_string(),

--- a/src/non_threadsafe/tests.rs
+++ b/src/non_threadsafe/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use assertor::*;
+use asserting::prelude::*;
 use proptest::collection::vec;
 use proptest::prelude::*;
 

--- a/src/threadsafe/tests.rs
+++ b/src/threadsafe/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use assertor::*;
+use asserting::prelude::*;
 use proptest::collection::vec;
 use proptest::prelude::*;
 use std::sync::{mpsc, RwLock};

--- a/tests/basic_example.rs
+++ b/tests/basic_example.rs
@@ -9,8 +9,6 @@
 
 mod fixture;
 
-#[allow(clippy::wildcard_imports)]
-use assertor::*;
 use output_tracker::non_threadsafe::{Error, OutputSubject, OutputTracker};
 use thiserror as _;
 
@@ -55,6 +53,8 @@ impl Adapter {
 // Tests
 //
 
+use asserting::prelude::*;
+
 #[test]
 fn send_message_via_adapter() {
     //
@@ -91,7 +91,7 @@ fn send_message_via_adapter() {
         .output()
         .unwrap_or_else(|err| panic!("failed to get output from tracker: {err}"));
 
-    assert_that!(tracker_output).contains_exactly_in_order(vec![
+    assert_that!(tracker_output).contains_exactly([
         Message {
             topic: "weather report".to_string(),
             content: "it will be snowing tomorrow".to_string(),

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -1,7 +1,7 @@
 // workaround for false positive 'unused extern crate' warnings until
 // Rust issue [#95513](https://github.com/rust-lang/rust/issues/95513) is fixed
 mod dummy_extern_uses {
-    use assertor as _;
+    use asserting as _;
     use output_tracker as _;
     use proptest as _;
     use thiserror as _;

--- a/tests/nullable_repository_example.rs
+++ b/tests/nullable_repository_example.rs
@@ -110,7 +110,7 @@ mod todo_repository {
 
 use crate::todo_domain::NewTodo;
 use crate::todo_repository::{TodoEntity, TodoRepository};
-use assertor::*;
+use asserting::prelude::*;
 
 #[test]
 fn insert_new_todo_item_into_repository() {
@@ -144,7 +144,7 @@ fn insert_new_todo_item_into_repository() {
         .output()
         .unwrap_or_else(|err| panic!("could not read output of todo tracker: {err}"));
 
-    assert_that!(inserted_todos).contains_exactly_in_order(vec![TodoEntity {
+    assert_that!(inserted_todos).contains_exactly([TodoEntity {
         subject: "remember the milk".into(),
     }]);
 }

--- a/tests/threadsafe_example.rs
+++ b/tests/threadsafe_example.rs
@@ -6,8 +6,6 @@
 //! difference is that the basic example uses the non-threadsafe variant.
 mod fixture;
 
-#[allow(clippy::wildcard_imports)]
-use assertor::*;
 use output_tracker::threadsafe::{Error, OutputSubject, OutputTracker};
 use thiserror as _;
 
@@ -52,6 +50,8 @@ impl Adapter {
 // Tests
 //
 
+use asserting::prelude::*;
+
 #[test]
 fn send_message_via_adapter() {
     //
@@ -88,7 +88,7 @@ fn send_message_via_adapter() {
         .output()
         .unwrap_or_else(|err| panic!("failed to get output from tracker: {err}"));
 
-    assert_that!(tracker_output).contains_exactly_in_order(vec![
+    assert_that!(tracker_output).contains_exactly([
         Message {
             topic: "weather report".to_string(),
             content: "it will be snowing tomorrow".to_string(),


### PR DESCRIPTION
we assertions in tests we want to use the new `asserting` crate instead of `assertor`.