### PR TITLE
chore: optimize ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,20 @@ permissions:
   contents: read
 
 jobs:
+  # Depends on all actions that are required for a "successful" CI run.
+  tests-pass:
+    name: all checks successful
+    runs-on: ubuntu-latest
+    needs:
+      - fmt
+      - clippy
+      - msrv
+      - doc
+      - test-all-features
+      - test-default-features
+    steps:
+      - run: exit 0
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -29,12 +43,12 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace
+          args: --all-features
+      - uses: Swatinem/rust-cache@v2
 
   fmt:
     name: Rustfmt check
@@ -48,10 +62,16 @@ jobs:
           toolchain: nightly
           components: rustfmt
       - run: cargo +nightly fmt --check --all
+      - uses: Swatinem/rust-cache@v2
 
-  test:
-    name: Run tests
+  test-all-features:
+    name: Run tests for all features
     runs-on: ${{ matrix.os }}
+    needs:
+      - fmt
+      - clippy
+      - msrv
+      - doc
     strategy:
       fail-fast: false
       matrix:
@@ -71,12 +91,34 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: Swatinem/rust-cache@v2
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features --no-fail-fast
+      - uses: Swatinem/rust-cache@v2
+
+  test-default-features:
+    name: Test with default features
+    runs-on: ubuntu-latest
+    needs:
+      - fmt
+      - clippy
+      - msrv
+      - doc
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+      - uses: Swatinem/rust-cache@v2
 
   msrv:
     name: Build with MSRV
@@ -113,9 +155,9 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - uses: Swatinem/rust-cache@v2
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
         with:
           command: doc
           args: --all-features --no-deps
+      - uses: Swatinem/rust-cache@v2

--- a/.ide-settings/jetbrains/runConfigurations/Clippy default-features.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Clippy default-features.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Clippy" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="clippy --all-targets --all-features" />
+  <configuration default="false" name="Clippy default-features" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="clippy --all-targets" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Clippy no-features.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Clippy no-features.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Clippy" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="clippy --all-targets --all-features" />
+  <configuration default="false" name="Clippy no-features" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="clippy --all-targets --no-default-features" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Test default-features.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test default-features.run.xml
@@ -1,6 +1,7 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Clippy" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="clippy --all-targets --all-features" />
+  <configuration default="false" name="Test default-features" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="test" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Test no-features.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test no-features.run.xml
@@ -1,6 +1,7 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Clippy" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="clippy --all-targets --all-features" />
+  <configuration default="false" name="Test no-features" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="test --no-default-features" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Test.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test.run.xml
@@ -6,8 +6,8 @@
     <envs />
     <option name="emulateTerminal" value="false" />
     <option name="channel" value="DEFAULT" />
-    <option name="requiredFeatures" value="true" />
-    <option name="allFeatures" value="true" />
+    <option name="requiredFeatures" value="false" />
+    <option name="allFeatures" value="false" />
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="NO" />

--- a/justfile
+++ b/justfile
@@ -7,7 +7,11 @@ alias c := check
 alias cc := code-coverage
 alias d := doc
 alias l := lint
+alias la := lint-all-features
+alias ld := lint-default
 alias t := test
+alias ta := test-all-features
+alias td := test-default
 alias tl := test-lib
 
 # list recipies
@@ -24,15 +28,33 @@ check:
 
 # linting code using Clippy
 lint:
+    just lint-default
+    just lint-all-features
+
+# linting code using Clippy with default features enabled
+lint-default:
+    cargo clippy --all-targets
+
+# linting code using Clippy with all features enabled
+lint-all-features:
     cargo clippy --all-targets --all-features
 
 # run all tests
 test:
-    cargo test --all-features
+    just test-default
+    just test-all-features
 
 # run unit tests only
 test-lib:
     cargo test --all-features --lib --bins
+
+# run tests for default features
+test-default:
+    cargo test
+
+# run tests for all features
+test-all-features:
+    cargo test --all-features
 
 # run code coverage (does not include doc-tests)
 code-coverage:

--- a/tests/basic_example.rs
+++ b/tests/basic_example.rs
@@ -10,7 +10,6 @@
 mod fixture;
 
 use output_tracker::non_threadsafe::{Error, OutputSubject, OutputTracker};
-use thiserror as _;
 
 //
 // Production code

--- a/tests/threadsafe_example.rs
+++ b/tests/threadsafe_example.rs
@@ -4,10 +4,12 @@
 //!
 //! This example is basically the same as the [`basic_example`]. The only
 //! difference is that the basic example uses the non-threadsafe variant.
+#![allow(unused_crate_dependencies)]
+#![cfg(feature = "threadsafe")]
+
 mod fixture;
 
 use output_tracker::threadsafe::{Error, OutputSubject, OutputTracker};
-use thiserror as _;
 
 //
 // Production code


### PR DESCRIPTION
The CI workflow - both the local workflow using just and the GitHub workflow - do not run clippy and tests with default features. Further the GitHub workflow does not play well with branch protection.

Added step to justfile as well as GitHub workflow that runs the tests with default features.
Added step to "summerize" workflow results for branch protection
Optimized CI GitHub workflow to run shorter steps before running the tests